### PR TITLE
Add a logger so honeybadger runs, grab overridden config

### DIFF
--- a/honeybadger.services.yml
+++ b/honeybadger.services.yml
@@ -3,3 +3,8 @@ services:
     arguments: ['@config.factory', '@request_stack']
   Honeybadger\Honeybadger:
     factory: ['@Drupal\honeybadger\HoneybadgerFactory', create]
+  logger.honeybadger:
+    class: Drupal\honeybadger\Logger\HoneybadgerLog
+    arguments: ['@Honeybadger\Honeybadger']
+    tags:
+      - { name: logger }

--- a/src/HoneybadgerFactory.php
+++ b/src/HoneybadgerFactory.php
@@ -41,7 +41,7 @@ final class HoneybadgerFactory {
    *   The honeybadger service.
    */
   public function create(array $config = []): Reporter {
-    $config = array_merge($config, $this->getConfig()->getRawData());
+    $config = array_merge($config, $this->getConfig()->getOriginal($key = '', $apply_overrides = TRUE));
     return Honeybadger::new($config);
   }
 

--- a/src/Logger/HoneybadgerLog.php
+++ b/src/Logger/HoneybadgerLog.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\honeybadger\Logger;
+
+use Drupal\Core\Logger\RfcLoggerTrait;
+use Honeybadger\Contracts\Reporter;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logs events in the watchdog database table.
+ */
+class HoneybadgerLog implements LoggerInterface {
+  use RfcLoggerTrait;
+
+  /**
+   * The honeybadger object.
+   *
+   * @var \Honeybadger\Contracts\Reporter
+   */
+  protected $honeybadger;
+
+  /**
+   * Add the honeybadger object.
+   *
+   * @param \Honeybadger\Contracts\Reporter $honeybadger
+   *   The honeybadger object.
+   */
+  public function __construct(Reporter $honeybadger) {
+    $this->honeybadger = $honeybadger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = []) {}
+
+}


### PR DESCRIPTION
The honeybadger class wasn't being instantiated. This creates a logger to ensure that honeybadger is present.

This also fixes an issue where the overridden config wasn't being grabbed.

I'm happy to discuss if you think there's a better way to get honeybadger running.

BTW, this still doesn't report all exceptions, but it does grab errors. I'm doing some investigation to see if I can log the exceptions to honeybadger through the log method of the logger.