### PR TITLE
Read the overridden config

### DIFF
--- a/src/HoneybadgerFactory.php
+++ b/src/HoneybadgerFactory.php
@@ -41,7 +41,7 @@ final class HoneybadgerFactory {
    *   The honeybadger service.
    */
   public function create(array $config = []): Reporter {
-    $config = array_merge($config, $this->getConfig()->getRawData());
+    $config = array_merge($config, $this->getConfig()->get());
     return Honeybadger::new($config);
   }
 


### PR DESCRIPTION
The getRawData method gets the data without overrides (see method comment at https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Config%21Config.php/8.8.x ).

Using the get method will read the overridden config from settings.php files.